### PR TITLE
initial version with networking modifications for eks-hybrid-nodes

### DIFF
--- a/cluster/eksctl/cluster.yaml
+++ b/cluster/eksctl/cluster.yaml
@@ -19,6 +19,11 @@ vpc:
   clusterEndpoints:
     privateAccess: true
     publicAccess: true
+remoteNetworkConfig:
+  remoteNodeNetworks:
+    - cidrs: ["10.52.1.0/24"]
+  remotePodNetworks:
+    - cidrs: ["10.52.2.0/24"]
 addons:
   - name: vpc-cni
     version: 1.19.2

--- a/cluster/terraform/eks.tf
+++ b/cluster/terraform/eks.tf
@@ -1,3 +1,16 @@
+locals {
+  remote_node_cidr = cidrsubnet(var.remote_network_cidr, 8, 1)
+  remote_pod_cidr  = cidrsubnet(var.remote_network_cidr, 8, 2)
+}
+
+module "eks_hybrid_node_role" {
+  source  = "terraform-aws-modules/eks/aws//modules/hybrid-node-role"
+  version = "~> 20.31"
+
+  tags = merge(local.tags, {
+    Terraform   = "true"
+  })
+}
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 20.0"
@@ -30,7 +43,33 @@ module "eks" {
 
   create_cluster_security_group = false
   create_node_security_group    = false
+  cluster_security_group_additional_rules = {
+    hybrid-all = {
+      cidr_blocks = [var.remote_network_cidr]
+      description = "Allow all traffic from remote node/pod network"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "all"
+      type        = "ingress"
+    }
+  }
 
+  access_entries = {
+    hybrid-node-role = {
+      principal_arn = module.eks_hybrid_node_role.arn
+      type          = "HYBRID_LINUX"
+    }
+  }
+
+  cluster_remote_network_config = {
+    remote_node_networks = {
+      cidrs = [local.remote_node_cidr]
+    }
+    # Required if running webhooks on Hybrid nodes
+    remote_pod_networks = {
+      cidrs = [local.remote_pod_cidr]
+    }
+  }
   eks_managed_node_groups = {
     default = {
       instance_types           = ["m5.large"]

--- a/cluster/terraform/variables.tf
+++ b/cluster/terraform/variables.tf
@@ -21,3 +21,9 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.42.0.0/16"
 }
+
+variable "remote_network_cidr" {
+  description = "Defines the remote CIDR blocks used on Amazon VPC created for Amazon EKS Hybrid Nodes."
+  type        = string
+  default     = "10.52.0.0/16"
+}

--- a/lab/iam/policies/ec2.yaml
+++ b/lab/iam/policies/ec2.yaml
@@ -48,6 +48,18 @@ Statement:
       - ec2:DeleteNatGateway
       - ec2:CreateNetworkInterface
       - ec2:DeleteNetworkInterface
+      - ec2:DescribeNetworkInterfaces
+      - ec2:CreateTransitGateway
+      - ec2:DeleteTransitGateway
+      - ec2:CreateTransitGatewayVpcAttachment
+      - ec2:DeleteTransitGatewayVpcAttachment
+      - ec2:ModifyNetworkInterfaceAttribute
+      - ec2:CreateNetworkInterfacePermission
+      - ec2:AssignIpv6Addresses
+      - ec2:UnAssignIpv6Addresses
+      - ec2:ImportKeyPair
+      - ec2:CreateKeyPair
+      - ec2:DeleteKeyPair
     Resource: ["*"]
   - Effect: Allow
     Action:

--- a/lab/scripts/installer.sh
+++ b/lab/scripts/installer.sh
@@ -9,7 +9,7 @@ kubectl_version='1.31.3'
 helm_version='3.16.4'
 
 # renovate: depName=eksctl-io/eksctl
-eksctl_version='0.203.0-rc.0'
+eksctl_version='0.203.0'
 
 kubeseal_version='0.18.4'
 

--- a/manifests/.workshop/terraform/base.tf
+++ b/manifests/.workshop/terraform/base.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.72.0"
+      version = "5.84.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/manifests/modules/networking/eks-hybrid-nodes/.workshop/terraform/vars.tf
+++ b/manifests/modules/networking/eks-hybrid-nodes/.workshop/terraform/vars.tf
@@ -33,3 +33,9 @@ variable "resources_precreated" {
   description = "Have expensive resources been created already"
   type        = bool
 }
+
+variable "remote_network_cidr" {
+  description = "Defines the remote CIDR blocks used on Amazon VPC created for Amazon EKS Hybrid Nodes."
+  type        = string
+  default     = "10.52.0.0/16"
+}


### PR DESCRIPTION
UPDATE: added config for networking components including TGW and routing


#### What this PR does / why we need it: modified base eksctl and terraform cluster config to launch eks clusters with hybrid nodes networking enabled.  Cleaned up the networking/eks-hybrid-nodes lab main.tf to add transit gateway and VPC routing.  Cleaned up terraform for consistency of tagging and naming.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ X] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
