### PR TITLE
pod routing

### DIFF
--- a/cluster/eksctl/cluster.yaml
+++ b/cluster/eksctl/cluster.yaml
@@ -23,7 +23,7 @@ remoteNetworkConfig:
   remoteNodeNetworks:
     - cidrs: ["10.52.0.0/16"]
   remotePodNetworks:
-    - cidrs: ["172.16.0.0/16"]
+    - cidrs: ["10.53.0.0/16"]
 addons:
   - name: vpc-cni
     version: 1.19.2

--- a/cluster/terraform/eks.tf
+++ b/cluster/terraform/eks.tf
@@ -1,6 +1,6 @@
 locals {
-  remote_node_cidr = cidrsubnet(var.remote_network_cidr, 8, 0)
-  remote_pod_cidr  = cidrsubnet(var.remote_network_cidr, 8, 1)
+  remote_node_cidr = var.remote_network_cidr
+  remote_pod_cidr  = var.remote_pod_cidr
 }
 
 module "eks" {
@@ -36,8 +36,17 @@ module "eks" {
   create_cluster_security_group = false
   create_node_security_group    = false
   cluster_security_group_additional_rules = {
-    hybrid-all = {
-      cidr_blocks = [var.remote_network_cidr]
+    hybrid-node = {
+      cidr_blocks = [local.remote_node_cidr]
+      description = "Allow all traffic from remote node/pod network"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "all"
+      type        = "ingress"
+    }
+
+    hybrid-pod = {
+      cidr_blocks = [local.remote_pod_cidr]
       description = "Allow all traffic from remote node/pod network"
       from_port   = 0
       to_port     = 0
@@ -48,7 +57,16 @@ module "eks" {
 
   node_security_group_additional_rules = {
     hybrid_node_rule = {
-      cidr_blocks = [var.remote_network_cidr]
+      cidr_blocks = [local.remote_node_cidr]
+      description = "Allow all traffic from remote node/pod network"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "all"
+      type        = "ingress"
+    }
+
+    hybrid_pod_rule = {
+      cidr_blocks = [local.remote_pod_cidr]
       description = "Allow all traffic from remote node/pod network"
       from_port   = 0
       to_port     = 0

--- a/cluster/terraform/variables.tf
+++ b/cluster/terraform/variables.tf
@@ -27,3 +27,9 @@ variable "remote_network_cidr" {
   type        = string
   default     = "10.52.0.0/16"
 }
+
+variable "remote_pod_cidr" {
+  description = "Defines the remote CIDR blocks used on Amazon VPC created for Amazon EKS Hybrid Nodes."
+  type        = string
+  default     = "10.53.0.0/16"
+}

--- a/lab/iam/policies/ec2.yaml
+++ b/lab/iam/policies/ec2.yaml
@@ -54,6 +54,9 @@ Statement:
       - ec2:DeleteTransitGateway
       - ec2:CreateTransitGatewayVpcAttachment
       - ec2:DeleteTransitGatewayVpcAttachment
+      - ec2:CreateTransitGatewayRoute
+      - ec2:SearchTransitGatewayRoutes
+      - ec2:DeleteTransitGatewayRoute
       - ec2:ModifyNetworkInterfaceAttribute
       - ec2:CreateNetworkInterfacePermission
       - ec2:AssignIpv6Addresses
@@ -89,10 +92,6 @@ Statement:
       - ec2:AuthorizeSecurityGroup*
       - ec2:RevokeSecurityGroup*
     Resource: ["*"]
-    Condition:
-      StringLike:
-        aws:ResourceTag/aws:eks:cluster-name:
-          - ${Env}*
   - Effect: Allow
     Action:
       - ec2:CreateTags

--- a/manifests/modules/networking/eks-hybrid-nodes/.workshop/terraform/main.tf
+++ b/manifests/modules/networking/eks-hybrid-nodes/.workshop/terraform/main.tf
@@ -306,14 +306,14 @@ resource "aws_route" "main_to_pod" {
 }
 
 # Add static route in tgw route table to reach pod cidr
-resource "aws_ec2_transit_gateway_route" "example" {
+resource "aws_ec2_transit_gateway_route" "tgw_route_to_pod" {
   destination_cidr_block         = local.remote_pod_cidr
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.remote.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway.tgw.association_default_route_table_id
 }
 
 # Add static route in remote route table to direct all pod traffic to node eni
-resource "aws_route" "route_to_pod" {
+resource "aws_route" "remote_route_to_pod" {
   route_table_id            = aws_route_table.remote_public.id
   destination_cidr_block    = local.remote_pod_cidr
   network_interface_id      = module.hybrid_node.primary_network_interface_id

--- a/manifests/modules/networking/eks-hybrid-nodes/cilium-values.yaml
+++ b/manifests/modules/networking/eks-hybrid-nodes/cilium-values.yaml
@@ -12,10 +12,13 @@ ipam:
   operator:
     clusterPoolIPv4MaskSize: 25
     clusterPoolIPv4PodCIDRList:
-    - 172.16.0.0/16
+    - 10.53.0.0/16
 operator:
   replicas: 1
   unmanagedPodWatcher:
     restart: false
 bgpControlPlane:
-  enabled: true
+  enabled: false
+routingMode: native
+ipv4NativeRoutingCIDR: 10.0.0.0/8
+enableIPv4Masquerade: true

--- a/manifests/modules/networking/eks-hybrid-nodes/kustomize/deployment.yaml
+++ b/manifests/modules/networking/eks-hybrid-nodes/kustomize/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: In
+                values:
+                - hybrid
+                

--- a/manifests/modules/networking/eks-hybrid-nodes/kustomize/kustomization.yaml
+++ b/manifests/modules/networking/eks-hybrid-nodes/kustomize/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base-application/ui
+patches:
+  - path: deployment.yaml


### PR DESCRIPTION
<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

1.  Set pod cidr to 10.53.x.x
2.  Add vpc routes, and add route to the tgw route table for the pod cidr. 
3.  Add route to the remote route table, dest pod cidr and target node eni.
4.  Add ingress rule to the cluster security group to allow node and pod traffic.
5.  Open the ingress rule for remote security group to allow inbound node and pod traffics from cluster vpc beyond cluster APi server. 
6.  Add kustomize for ui to select hybrid node for testing

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
